### PR TITLE
Net core support for NET45

### DIFF
--- a/ExpressMapper NET45/ExpressMapper NET45.csproj
+++ b/ExpressMapper NET45/ExpressMapper NET45.csproj
@@ -139,6 +139,9 @@
     <Compile Include="..\ExpressMapper NET40\SubstituteParameterVisitor.cs">
       <Link>SubstituteParameterVisitor.cs</Link>
     </Compile>
+    <Compile Include="..\ExpressMapper NET40\TypeExtensions.cs">  
+      <Link>TypeExtensions.cs</Link>  
+    </Compile> 
     <Compile Include="..\ExpressMapper NET40\TypeMapperBase.cs">
       <Link>TypeMapperBase.cs</Link>
     </Compile>


### PR DESCRIPTION
After update nuget package to version 1.8.2 for net45, an exception is raised when a RegisterCustom method is invoked.
The exception is System.TypeLoadExcpetion and the message is 'Could not load type 'ExpressMapper.TypeExtensions' from assembly 'ExpressMapper, Version=1.8.2.0, Culture=neutral, PublicKeyToken=ac363faa09311ba0'.'
On commit 64d65b022206792d8b4c68cd46cbe97e49a8a534 was added the file ExpressMapper NET40/TypeExtensions.cs but  ExpressMapper NET45/ExpressMapper NET45.csproj was not updated.
Perhaps another projects need this too.