### PR TITLE
Fix NullReferenceException in MemberConfiguration

### DIFF
--- a/ExpressMapper NET40/MemberConfiguration.cs
+++ b/ExpressMapper NET40/MemberConfiguration.cs
@@ -93,7 +93,7 @@ namespace ExpressMapper
 
             var propertyInfo = memberExpression.Member as PropertyInfo;
 
-            if (propertyInfo != null && !propertyInfo.CanWrite && !propertyInfo.GetSetMethod(true).IsPublic)
+            if (propertyInfo != null && !propertyInfo.CanWrite || (propertyInfo != null && propertyInfo.CanWrite && !propertyInfo.GetSetMethod(true).IsPublic))
             {
                 Ignore(dest);
             }


### PR DESCRIPTION
Fix an issue where calling `MemberConfiguration.Function(...)` throws `NullReferenceException` if destination property is read-only.

Note that the fix is a simple copy-paste from the read-only check in `MemberConfiguration.Member(...)`. Following the _DRY principle_, this read-only check would ideally be extracted to a method.