### PR TITLE
Fix nullpointer when mapping from a null source or to null destination

### DIFF
--- a/ExpressMapper NETCORE/MappingServiceProvider.cs
+++ b/ExpressMapper NETCORE/MappingServiceProvider.cs
@@ -276,7 +276,7 @@ namespace ExpressMapper
 
         public TN Map<T, TN>(T src)
         {
-            if (src.GetType() == typeof(T))
+            if (src == null || src.GetType() == typeof(T))
             {
                 return MapInternal<T, TN>(src);
             }
@@ -285,7 +285,7 @@ namespace ExpressMapper
 
         public TN Map<T, TN>(T src, TN dest)
         {
-            if (src.GetType() == typeof(T) && (dest.GetType() == typeof(TN)))
+            if ((src == null || src.GetType() == typeof(T)) && (dest == null || dest.GetType() == typeof(TN)))
             {
                 return MapInternal<T, TN>(src, dest);
             }

--- a/ExpressMapper.Tests NET40/BasicTests.cs
+++ b/ExpressMapper.Tests NET40/BasicTests.cs
@@ -1418,5 +1418,15 @@ namespace ExpressMapper.Tests
             Assert.AreEqual(uiViewModel.ControlViewModel.name_ctrl, textBox.Name);
             Assert.AreEqual(((TextBoxViewModel)uiViewModel.ControlViewModel).Text, textBox.Text);
         }
+
+        [Test]
+        public void MapNullSourceReturnNullDest()
+        {
+            Mapper.Register<object, object>();
+            Mapper.Compile();
+
+            Assert.IsNull(Mapper.Map<object, object>(null));
+            Assert.IsNull(Mapper.Map<object, object>(null, (object)null));
+        }
     }
 }

--- a/ExpressMapper.Tests NETCORE/BasicTests.cs
+++ b/ExpressMapper.Tests NETCORE/BasicTests.cs
@@ -1397,5 +1397,15 @@ namespace ExpressMapper.Tests
             Assert.AreEqual(uiViewModel.ControlViewModel.name_ctrl, textBox.Name);
             Assert.AreEqual(((TextBoxViewModel)uiViewModel.ControlViewModel).Text, textBox.Text);
         }
+
+        [Test]
+        public void MapNullSourceReturnNullDest()
+        {
+            Mapper.Register<object, object>();
+            Mapper.Compile();
+
+            Assert.IsNull(Mapper.Map<object, object>(null));
+            Assert.IsNull(Mapper.Map<object, object>(null, (object)null));
+        }
     }
 }

--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -276,7 +276,7 @@ namespace ExpressMapper
 
         public TN Map<T, TN>(T src)
         {
-            if (src.GetType() == typeof(T))
+            if (src == null || src.GetType() == typeof(T))
             {
                 return MapInternal<T, TN>(src);
             }
@@ -285,7 +285,7 @@ namespace ExpressMapper
 
         public TN Map<T, TN>(T src, TN dest)
         {
-            if (src.GetType() == typeof(T) && (dest.GetType() == typeof(TN)))
+            if ((src == null || src.GetType() == typeof(T)) && (dest == null || dest.GetType() == typeof(TN)))
             {
                 return MapInternal<T, TN>(src, dest);
             }


### PR DESCRIPTION
Hopefully this is the fix to an issue I experienced, when i was trying to upgrade from version 1.8 to 1.9 where the new version throws a NPE, when trying to map null objects.